### PR TITLE
Bugfix: Prevent code run from stopping if workbench.action.terminal.clear can't be executed.

### DIFF
--- a/src/runner/codeManager.js
+++ b/src/runner/codeManager.js
@@ -256,7 +256,12 @@ class CodeManager {
             let command = yield this.getFinalCommandToRunCodeFile(executor, appendFile);
             command = this.changeFilePathForBashOnWindows(command);
             if (!isNewTerminal) {
-                yield vscode.commands.executeCommand("workbench.action.terminal.clear");
+                try {
+                    yield vscode.commands.executeCommand("workbench.action.terminal.clear"); 
+                } 
+                catch (e) { 
+                    console.warn("vscode-markdown-code-runner: workbench.action.terminal.clear could not execute, skipping")
+                }
             }
             this._terminal.sendText(command);
         });


### PR DESCRIPTION
I've been testing vscode-markdown-code-runner in other environments such as Eclipse Theia, and noticed it can sometimes not work and generate an error along the lines of "'workbench.action.terminal.clear' is not registered", which ends up making the 'code run' not happen.

This workaround wraps the line in a try/catch block so the code run will still happens in case workbench.action.terminal.clear can't be executed.